### PR TITLE
Add an option to print the abspath instead of relative path

### DIFF
--- a/ffind
+++ b/ffind
@@ -467,6 +467,9 @@ def _search(query, dir, depth, ignorers):
 
     for item in contents:
         path = os.path.join(dir, item)
+        if options.print_fullname:
+            path = os.path.abspath(path)
+
         if not should_ignore(item, path, ignorers):
             if match(query, path, item):
                 out(path, '\0' if options.zero else '\n')
@@ -517,6 +520,9 @@ def build_option_parser():
     p.add_option('-E', '--non-entire', dest='entire',
                  action='store_false',
                  help='match PATTERN against only the filenames (default)')
+    p.add_option('-p', '--fullname', dest='print_fullname',
+                  action='store_true', default=False,
+                  help="print the file's full name")
 
     # Case sensitivity
     g = OptionGroup(p, "Configuring Case Sensitivity")


### PR DESCRIPTION
Unix find, by default, prints the full path of the files it finds. I think this is more useful behavior than the one currently used by ffind, so I added a -p option to print the full name of the file.

A comparison:

```
$ ./ffind -d /usr/share/locale/ af_*
./af_ZA
./af_ZA.ISO8859-1
./af_ZA.ISO8859-15
./af_ZA.UTF-8

$ ./ffind -p -d /usr/share/locale/ af_*
/usr/share/locale/af_ZA
/usr/share/locale/af_ZA.ISO8859-1
/usr/share/locale/af_ZA.ISO8859-15
/usr/share/locale/af_ZA.UTF-8
```

This is suitable for piping into xargs, and generally more useful than paths starting with "./".

I'd love to make this the default behavior, but I've left it off by default out of respect for your current design. If you agree that it ought to be the default, I'll be happy to change it.