### PR TITLE
python3 compatibility fix

### DIFF
--- a/ffind
+++ b/ffind
@@ -699,7 +699,7 @@ def is_re(s):
 
     """
 
-    return not all(c.lower() in string.letters + '_-' for c in s)
+    return not all(c.lower() in string.ascii_letters + '_-' for c in s)
 
 
 def clean_ago_piece(n, unit):


### PR DESCRIPTION
From [P3 what's new page](http://docs.python.org/3.0/whatsnew/3.0.html)

string.letters and its friends (string.lowercase and string.uppercase) are gone. Use string.ascii_letters etc. instead. (The reason for the removal is that string.letters and friends had locale-specific behavior, which is a bad idea for such attractively-named global “constants”.)
