### PR TITLE
Add in a manpage

### DIFF
--- a/ffind.1
+++ b/ffind.1
@@ -1,0 +1,151 @@
+.TH FFIND 1 2014-02-13  
+
+.SH NAME
+ffind \-  find replacement focussed on usability
+
+.SH SYNOPSIS
+.B ffind 
+[\fIoption\fR]...  [\fIPATTERN\fR]
+
+.SH DESCRIPTION
+.B ffind 
+is intended as a more usable replacement for \fBfind(1)\fR.
+.B ffind
+searches the directory tree rooted at each given file name by evaluating the
+given search pattern (\fIPATTERN\fR)..
+
+.SH OPTIONS
+.TP
+.BR \-d ", " \-\-dir " " \fIDIR\fR
+Root the search in '\fIDIR\fR' (default is '.').
+.TP
+.BR \-D ", " \-\-depth " " \fIN\fR
+Search at most \fIN\fR directories deep (default is 25).
+.TP
+.BR \-f ", " \-\-follow
+Follow symlinked directories and search their contents.
+.TP
+.BR \-F ", " \-\-nofollow
+Don't follow symlinked directories (default).
+.TP
+.BR \-0 ", " \-\-print0
+Separate matches with a null byte in output.
+.TP
+.BR \-l ", " \-\-literal
+Force literal search, even if it looks like a regex.
+.TP
+.BR \-v ", " \-\-invert
+Invert match.
+.TP
+.BR \-e ", " \-\-entire
+match \fIPATTERN\fR against the entire path string.
+.TP
+.BR \-E ", " \-\-non\-entire
+match \fIPATTERN\fR against only the filenames (default).
+.TP
+.BR \-s ", " \-\-case-sensitive
+case sensitive matching (default).
+.TP
+.BR \-i ", " \-\-case-insensitive
+case insensitive matching.
+.TP
+.BR \-S ", " \-\-case-smart
+Smart case matching (sensitive if any uppercase chars are in the pattern,
+insensitive otherwise)
+.TP
+.BR \-b ", " \-\-binary
+Allow binary files (default).
+.TP
+.BR \-B ", " \-\-no-binary
+Ignore binary files.
+.TP
+.BR \-r ", " \-\-restricted
+Restricted search (skip VCS directories, parse all ignore files) (default).
+.TP
+.BR \-q ", " \-\-semi-restricted
+Semi-restricted search (don't parse VCS ignore files, but still skip VCS
+directories and parse .ffignore).
+.TP
+.BR \-u ", " \-\-unrestricted
+unrestricted search (don't parse ignore files, but still skip VCS directories).
+.TP
+.BR \-a ", " \-\-all
+Don't ignore anything (ALL files can match).
+.TP
+.BR \-\-larger-than=\fISIZE\fR ", " --bigger-than=\fISIZE\fR
+match files larger than \fISIZE\fR (inclusive)
+.TP
+.BR \-\-smaller-than=\fISIZE\fR
+match files smaller than \fISIZE\fR (inclusive)
+.PP
+Sizes can be given as a number followed by a prefix. Some examples: 1k, 5kb,
+1.5gb, 2g, 1024b.
+.PP
+Filtering can also be done by type. Possible types are \fIa\fR (all), \fIf\fR
+(files), d (dirs), \fIr\fR (real), \fIs\fR (symlinked), \fIe\fR (real files),
+\fIc\fR (real dirs), \fIx\fR (symlinked files), \fIy\fR (symlinked dirs). If
+multiple types are given they will be unioned together:  \fB--type\fR
+\'\fIes\fR\' would match real files and all symlinks.
+.TP
+.BR \-t " " \fITYPE(s)\fR ", " \-\-type=\fITYPE(s)\fR
+match only specific types of things (files, dirs, non- symlinks, symlinks).
+.PP
+
+.SH FILES
+.TP
+.BR .ffignore
+Containins lines with patterns to ignore.
+
+.SH FFIGNORE FORMAT
+The .ffignore file is a file containing lines with patterns to ignore, with a few exceptions:
+.IP
+Blank lines and whitespace-only are skipped. If you want to ignore files whose
+names consist of only whitespace use a regex. Or reconsider what got you there
+in the first place.
+.IP
+Lines beginning with a \fB#\fR are comments and are skipped. There can be
+whitespace before the \fB#\fR as well.
+.IP
+Lines of the form (\fIliteral\fR|\fIregex\fR)' change the mode of the lines
+following them, much like Mercurial's ignore file format. The default is regex
+mode.
+.IP
+All other lines are treated as patterns to ignore.
+.PP
+All patterns are unrooted, and search the full path from the directory you're
+searching in. Use a regex with \fB^\fR if you want to root them.  For example:
+.PP
+.RS
+foo.*bar
+.RE
+.PP
+Will ignore:
+.PP
+.RS
+ ./foobar\.txt
+ ./foohello\/world\/bar\.txt
+.RE
+
+.SH BUGS
+.PP
+Time filtering is unimplemented.
+.PP
+SVN ignores aren't parsed.
+.PP
+It's pretty slow (though pruning VCS data directories saves lots of time).
+.PP
+Feedback is welcome:
+.IP
+http://github.com/sjl/friendly-find/
+.IP
+http://bitbucket.org/sjl/friendly-find/
+
+.SH AUTHORS
+Steve Losh
+(steve@stevelosh.com)
+
+.SH LICENSE
+Copyright 2012 Steve Losh and contributors. Licensed under version 3 of the GPL.
+
+.SH SEE ALSO
+\fBfind(1)\fR


### PR DESCRIPTION
I wrote a manpage for ffind, mostly just adapting the documentation from the
README.  Currently the ffind build process doesn't allow for its being copied
to /usr/share/man automatically and so will have to be moved there manually by
the user, but that is a separate issue.
